### PR TITLE
Change .ssh mode to follow the ssh recommendations.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: ruby
 rvm:
-  - 1.8.7
   - 1.9.3
+  - 2.2.7
+  - 2.3.4
+  - 2.4.1
 script:
   - "rake spec SPEC_OPTS='--format documentation'"
 env:
@@ -9,6 +11,10 @@ env:
   - PUPPET_VERSION="~> 2.7.0"
   - PUPPET_VERSION="~> 3.0.0"
   - PUPPET_VERSION="~> 3.1.0"
+  - PUPPET_VERSION="~> 3.5.1"
+  - PUPPET_VERSION="~> 3.8.7"
+  - PUPPET_VERSION="~> 4.5.3"
+  - PUPPET_VERSION="~> 4.9.4"
 matrix:
   exclude:
     - rvm: 1.9.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ rvm:
 script:
   - "rake spec SPEC_OPTS='--format documentation'"
 env:
-  - PUPPET_VERSION="~> 2.6.0"
   - PUPPET_VERSION="~> 2.7.0"
   - PUPPET_VERSION="~> 3.0.0"
   - PUPPET_VERSION="~> 3.1.0"
@@ -17,8 +16,50 @@ env:
   - PUPPET_VERSION="~> 4.9.4"
 matrix:
   exclude:
-    - rvm: 1.9.3
-      env: PUPPET_VERSION="~> 2.6.0"
+    - rvm: 2.2.7
+      env: PUPPET_VERSION="~> 2.7.0"
+      gemfile: .gemfile
+    - rvm: 2.2.7
+      env: PUPPET_VERSION="~> 3.0.0"
+      gemfile: .gemfile
+    - rvm: 2.2.7
+      env: PUPPET_VERSION="~> 3.1.0"
+      gemfile: .gemfile
+    - rvm: 2.2.7
+      env: PUPPET_VERSION="~> 3.5.1"
+      gemfile: .gemfile
+    - rvm: 2.2.7
+      env: PUPPET_VERSION="~> 3.8.7"
+      gemfile: .gemfile
+    - rvm: 2.3.4
+      env: PUPPET_VERSION="~> 2.7.0"
+      gemfile: .gemfile
+    - rvm: 2.3.4
+      env: PUPPET_VERSION="~> 3.0.0"
+      gemfile: .gemfile
+    - rvm: 2.3.4
+      env: PUPPET_VERSION="~> 3.1.0"
+      gemfile: .gemfile
+    - rvm: 2.3.4
+      env: PUPPET_VERSION="~> 3.5.1"
+      gemfile: .gemfile
+    - rvm: 2.3.4
+      env: PUPPET_VERSION="~> 3.8.7"
+      gemfile: .gemfile
+    - rvm: 2.4.1
+      env: PUPPET_VERSION="~> 2.7.0"
+      gemfile: .gemfile
+    - rvm: 2.4.1
+      env: PUPPET_VERSION="~> 3.0.0"
+      gemfile: .gemfile
+    - rvm: 2.4.1
+      env: PUPPET_VERSION="~> 3.1.0"
+      gemfile: .gemfile
+    - rvm: 2.4.1
+      env: PUPPET_VERSION="~> 3.5.1"
+      gemfile: .gemfile
+    - rvm: 2.4.1
+      env: PUPPET_VERSION="~> 3.8.7"
       gemfile: .gemfile
 
 gemfile: .gemfile

--- a/manifests/managed.pp
+++ b/manifests/managed.pp
@@ -98,7 +98,7 @@ define user::managed(
       require  => File[$real_homedir],
       owner    => $name,
       group    => $name,
-      mode     => $homedir_mode,
+      mode     => '0700',
     }
   }
 


### PR DESCRIPTION
In order to follow the ssh recommendations.

```
$> man ssh
  (...)
~/.ssh/
This directory is the default location for all user-specific configuration and authentication
information. There is no general requirement to keep the entire contents of this directory secret,
but the recommended permissions are read/write/execute for the user, and not accessible by others.
```